### PR TITLE
[RFR] Ensure filter field cannot be require

### DIFF
--- a/lib/View/ListView.js
+++ b/lib/View/ListView.js
@@ -96,6 +96,9 @@ class ListView extends View {
         }
 
         this._filters = orderElement.order(filters);
+        
+        // a filter cannot be required
+        this._filters.map((filter) => filter.validation({ required: false }));
 
         return this;
     }

--- a/tests/lib/View/ListViewTest.js
+++ b/tests/lib/View/ListViewTest.js
@@ -26,4 +26,23 @@ describe('ListView', function() {
             assert.deepEqual({category: category}, view.getFilterReferences());
         });
     });
+
+    describe('filters()', function() {
+        it('should return ordered filters field without any field required validation', function() {
+            var post = new Entity('post');
+            var category = new ReferenceField('category');
+            var title = (new Field('title')).validation({ required: true });
+            var view = new ListView(post)
+                .fields([
+                    title
+                ])
+                .filters([
+                    title.order(2),
+                    category.order(1)
+                ]);
+
+            assert.deepEqual([ category, title ], view.filters());
+            assert.equal(view.filters()[0].validation().required, false);
+        });
+    });
 });


### PR DESCRIPTION
Because on an updated project with last version of ng-admin, a required filter field become required, so the validation required configuration was ignored.