### PR TITLE
[RFR] Fix DateTime type

### DIFF
--- a/lib/Field/DateTimeField.js
+++ b/lib/Field/DateTimeField.js
@@ -7,7 +7,8 @@ class DateTimeField extends DateField {
         this._parse = function(date) {
             return date;
         }
+        this._type = 'datetime';
     }
 }
 
-export default DateField;
+export default DateTimeField;


### PR DESCRIPTION
Any field declared as type `datetime` used to return a `date` since ES6 refactoring, due to a typo.

This PR should also fix https://github.com/marmelab/ng-admin/issues/420.