### PR TITLE
added methods to define which http method to use on create or update

### DIFF
--- a/lib/Entity/Entity.js
+++ b/lib/Entity/Entity.js
@@ -23,6 +23,9 @@ class Entity {
         this._errorMessage = null;
         this._order = 0;
         this._url = null;
+        this._createMethod = null; // manually set the HTTP-method for create operation, defaults to post
+        this._updateMethod = null; // manually set the HTTP-method for update operation, defaults to put
+
 
         this._initViews();
     }
@@ -193,6 +196,18 @@ class Entity {
         }
 
         return this._url;
+    }
+
+    createMethod(createMethod) {
+        if (!arguments.length) return this._createMethod;
+        this._createMethod = createMethod;
+        return this;
+    }
+
+    updateMethod(updateMethod) {
+        if (!arguments.length) return this._updateMethod;
+        this._updateMethod = updateMethod;
+        return this;
     }
 }
 

--- a/lib/Queries/WriteQueries.js
+++ b/lib/Queries/WriteQueries.js
@@ -13,7 +13,7 @@ class WriteQueries extends Queries {
      */
     createOne(view, rawEntity) {
         return this._restWrapper
-            .createOne(rawEntity, view.entity.name(), this._application.getRouteFor(view.entity, view.getUrl(), view.type));
+            .createOne(rawEntity, view.entity.name(), this._application.getRouteFor(view.entity, view.getUrl(), view.type), view.entity.createMethod());
     }
 
     /**
@@ -31,7 +31,7 @@ class WriteQueries extends Queries {
 
         // Update element data
         return this._restWrapper
-            .updateOne(rawEntity, view.entity.name(), this._application.getRouteFor(view.entity, view.getUrl(entityId), view.type, entityId, view.identifier()));
+            .updateOne(rawEntity, view.entity.name(), this._application.getRouteFor(view.entity, view.getUrl(entityId), view.type, entityId, view.identifier()), view.entity.updateMethod());
     }
 
     /**

--- a/tests/lib/Entity/EntityTest.js
+++ b/tests/lib/Entity/EntityTest.js
@@ -61,4 +61,28 @@ describe('Entity', function() {
             assert.equal(false, entity.deletionView().enabled);
         });
     })
+    
+    describe('createMethod', function() {
+        it('should return given createMethod if already set', function() {
+            var post = new Entity('post').createMethod("put");
+            assert.equal('put', post.createMethod());
+        });
+
+        it('should return null if no createMethod has been set', function() {
+            var post = new Entity('post');
+            assert.equal(null, post.createMethod());
+        });
+    });
+    
+    describe('updateMethod', function() {
+        it('should return given updateMethod if already set', function() {
+            var post = new Entity('post').updateMethod("post");
+            assert.equal('post', post.updateMethod());
+        });
+
+        it('should return null if no updateMethod has been set', function() {
+            var post = new Entity('post');
+            assert.equal(null, post.updateMethod());
+        });
+    });
 });


### PR DESCRIPTION
Hi,

this is the new version for my pull request which I started originally with marmelab/ng-admin#451. This is the part which happens here, the corresponding part is in marmelab/ng-admin#491. I hope this is the right way to do it. Not sure though.

WDYT?