### PR TITLE
[RFR] Use babel instead of traceur for test files preprocessing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ install:
 	@npm install
 
 test:
-	@./node_modules/mocha/bin/mocha --compilers js:mocha-traceur --recursive tests/
+	@./node_modules/mocha/bin/mocha --compilers js:babel/register --recursive tests/

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "node": ">=0.10.0"
   },
   "devDependencies": {
+    "babel": "^5.5.3",
     "chai": "^2.3.0",
     "mocha": "^2.2.5",
-    "mocha-traceur": "^2.1.0",
     "sinon": "^1.14.1"
   },
   "scripts": {


### PR DESCRIPTION
Because we use Babel in both ng-admin and react-admin.