### PR TITLE
[RFR] Introducing dashboard and collections

### DIFF
--- a/lib/Application.js
+++ b/lib/Application.js
@@ -1,4 +1,6 @@
 import Menu from './Menu/Menu';
+import Collection from './Collection';
+import Dashboard from './Dashboard';
 import orderElement from "./Utils/orderElement";
 
 class Application {
@@ -7,6 +9,7 @@ class Application {
         this._customTemplate = function(viewName) {};
         this._title = title;
         this._menu = null;
+        this._dashboard = null;
         this._layout = false;
         this._header = false;
         this._entities = [];
@@ -114,6 +117,36 @@ class Application {
             .sort((e1, e2) => e1.menuView().order() - e2.menuView().order())
             .map(entity => new Menu().populateFromEntity(entity))
         );
+    }
+
+    dashboard(dashboard) {
+        if (!arguments.length) {
+                if (!this._dashboard) {
+                    this._dashboard = this.buildDashboardFromEntities();
+                }
+                return this._dashboard
+        }
+        this._dashboard = dashboard;
+        return this;
+    }
+
+    buildDashboardFromEntities() {
+        let dashboard = new Dashboard()
+        this.entities
+            .filter(entity => entity.dashboardView().enabled)
+            .map(entity => {
+                dashboard.addCollection(entity.name(), entity.dashboardView()); // yep, a collection is a ListView, and so is a DashboardView - forgive this duck typing for BC sake
+            });
+        if (!dashboard.hasCollections()) {
+            // still no collection from dashboardViews, let's use listViews instead
+            this.entities
+                .filter(entity => entity.listView().enabled)
+                .map(entity => {
+                    // TODO: clone listView into a Collection, and keep only the first n fields
+                    dashboard.addCollection(entity.name(), entity.listView());
+                });
+        }
+        return dashboard;
     }
 
     customTemplate(customTemplate) {

--- a/lib/Application.js
+++ b/lib/Application.js
@@ -141,9 +141,17 @@ class Application {
             // still no collection from dashboardViews, let's use listViews instead
             this.entities
                 .filter(entity => entity.listView().enabled)
-                .map(entity => {
-                    // TODO: clone listView into a Collection, and keep only the first n fields
-                    dashboard.addCollection(entity.name(), entity.listView());
+                .map((entity, index) => {
+                    let collection = new Collection();
+                    let listView = entity.listView()
+                    collection.setEntity(entity);
+                    collection.perPage(listView.perPage())
+                    collection.sortField(listView.sortField())
+                    collection.sortDir(listView.sortDir())
+                    collection.order(index);
+                    // use only the first 3 cols
+                    collection.fields(listView.fields().filter((el, index) => index < 3));
+                    dashboard.addCollection(entity.name(), collection);
                 });
         }
         return dashboard;

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -1,0 +1,10 @@
+import ListView from './View/ListView';
+
+class Collection extends ListView {
+    constructor(name) {
+        super(name);
+        this._type = 'collection';
+    }
+}
+
+export default Collection;

--- a/lib/Dashboard.js
+++ b/lib/Dashboard.js
@@ -1,0 +1,33 @@
+class Dashboard {
+    constructor() {
+        this._collections = {};
+        this._template = null;
+    }
+
+    addCollection(name, collection) {
+        this._collections[name] = collection;
+        return this;
+    }
+
+    collections(collections) {
+        if (arguments.length) {
+            this._collections = collections;
+            return this;
+        }
+        return this._collections;
+    }
+
+    hasCollections() {
+        return Object.keys(this._collections).length > 0;
+    }
+
+    template(template) {
+        if (arguments.length) {
+            this._template = template;
+            return this;
+        }
+        return this._template;        
+    }
+}
+
+export default Dashboard;

--- a/lib/Factory.js
+++ b/lib/Factory.js
@@ -27,6 +27,7 @@ import WysiwygField from "./Field/WysiwygField";
 
 import Menu from './Menu/Menu';
 import Collection from './Collection';
+import Dashboard from './Dashboard';
 
 class Factory {
     constructor() {
@@ -66,6 +67,10 @@ class Factory {
             menu.populateFromEntity(entity);
         }
         return menu;
+    }
+
+    dashboard() {
+        return new Dashboard();
     }
 
     collection(entity) {

--- a/lib/Factory.js
+++ b/lib/Factory.js
@@ -26,6 +26,7 @@ import TextField from "./Field/TextField";
 import WysiwygField from "./Field/WysiwygField";
 
 import Menu from './Menu/Menu';
+import Collection from './Collection';
 
 class Factory {
     constructor() {
@@ -65,6 +66,14 @@ class Factory {
             menu.populateFromEntity(entity);
         }
         return menu;
+    }
+
+    collection(entity) {
+        let collection = new Collection();
+        if (entity) {
+            collection.setEntity(entity);
+        }
+        return collection;
     }
 
     getDataStore() {

--- a/lib/View/View.js
+++ b/lib/View/View.js
@@ -101,6 +101,37 @@ class View {
         return this;
     }
 
+    hasFields() {
+        return this.fields.length > 0;
+    }
+
+    removeFields() {
+        this._fields = [];
+        return this;
+    }
+
+    getFields() {
+        return this._fields;
+    }
+
+    getField(fieldName) {
+        return this._fields.filter(f => f.name() === fieldName)[0];
+    }
+
+    getFieldsOfType(type) {
+        return this._fields.filter(f => f.type() === type);
+    }
+
+    addField(field) {
+        if (field.order() === null) {
+            field.order(this._fields.length, true);
+        }
+        this._fields.push(field);
+        this._fields = this._fields.sort((a, b) => (a.order() - b.order()));
+
+        return this;
+    }
+
     static flatten(arg) {
         if (arg.constructor.name === 'Object') {
             console.warn('Passing literal of Field to fields method is deprecated use array instead');
@@ -176,33 +207,6 @@ class View {
     actions(actions) {
         if (!arguments.length) return this._actions;
         this._actions = actions;
-        return this;
-    }
-
-    removeFields() {
-        this._fields = [];
-        return this;
-    }
-
-    getFields() {
-        return this._fields;
-    }
-
-    getField(fieldName) {
-        return this._fields.filter(f => f.name() === fieldName)[0];
-    }
-
-    getFieldsOfType(type) {
-        return this._fields.filter(f => f.type() === type);
-    }
-
-    addField(field) {
-        if (field.order() === null) {
-            field.order(this._fields.length, true);
-        }
-        this._fields.push(field);
-        this._fields = this._fields.sort((a, b) => (a.order() - b.order()));
-
         return this;
     }
 

--- a/tests/lib/ApplicationTest.js
+++ b/tests/lib/ApplicationTest.js
@@ -268,7 +268,9 @@ describe('Application', function() {
                 post = new Entity('post'),
                 fields = [
                     new Field('field1'),
-                    new Field('field2')
+                    new Field('field2'),
+                    new Field('field3'),
+                    new Field('field4')                    
                 ];
 
             comment.listView().fields(fields);
@@ -281,7 +283,7 @@ describe('Application', function() {
             assert.property(dashboard.collections(), 'comment');
             assert.notProperty(dashboard.collections(), 'post');
             let commentCollection = dashboard.collections().comment;
-            assert.deepEqual(commentCollection.fields(), fields);
+            assert.deepEqual(commentCollection.fields(), fields.filter((el, i) => i < 3));
         });
     });
 });

--- a/tests/lib/DashboardTest.js
+++ b/tests/lib/DashboardTest.js
@@ -1,0 +1,50 @@
+var assert = require('chai').assert;
+
+import Dashboard from "../../lib/Dashboard";
+
+describe('Dashboard', () => {
+    describe('collections()', () => {
+        it('should be an empty object by default', () => {
+            assert.deepEqual(new Dashboard().collections(), {})
+        });
+    });
+    describe('addCollection()', () => {
+        it('should add a collection', () => {
+            let dashboard = new Dashboard();
+            const collection = { IAmAFakeCollection: true }; 
+            dashboard.addCollection('foo', collection);
+            assert.deepEqual(dashboard.collections(), { foo: collection })
+        });
+    });
+    describe('hasCollections()', () => {
+        it('should return false for empty dashboards', () => {
+            let dashboard = new Dashboard();
+            assert.notOk(dashboard.hasCollections());
+        });
+        it('should return true for non-empty dashboards', () => {
+            let dashboard = new Dashboard();
+            dashboard.addCollection('foo', {});
+            assert.ok(dashboard.hasCollections());
+        });
+    });
+    describe('template()', () => {
+        it('should return null by default', () => {
+            let dashboard = new Dashboard();
+            assert.isNull(dashboard.template());
+        });
+        it('should return the template when called with no argument', () => {
+            let dashboard = new Dashboard();
+            dashboard._template = 'foo';
+            assert.equal('foo', dashboard.template());
+        });
+        it('should set the template when called with an argument', () => {
+            let dashboard = new Dashboard();
+            dashboard.template('foo');
+            assert.equal('foo', dashboard.template());
+        });
+        it('should return the dashboard when called with an argument', () => {
+            let dashboard = new Dashboard();
+            assert.strictEqual(dashboard, dashboard.template('bar'));
+        });
+    });
+});

--- a/tests/lib/FactoryTest.js
+++ b/tests/lib/FactoryTest.js
@@ -1,5 +1,6 @@
 import Factory from "../../lib/Factory";
 import Field from "../../lib/Field/Field";
+import Collection from "../../lib/Collection";
 
 var assert = require('chai').assert;
 
@@ -42,4 +43,15 @@ describe('Factory', function() {
             assert.equal('string', field.type());
         });
     });
+
+    describe('collection()', () => {
+        it('should return a new Collection with the correct entity', () => {
+            var factory = new Factory();
+            var dummyEntity = { name: () => 'foo' };
+            var collection = factory.collection(dummyEntity);
+            assert.instanceOf(collection, Collection);
+            assert.equal(collection.getEntity(), dummyEntity);
+            assert.equal(collection.name(), 'foo_collection');
+        })
+    })
 });


### PR DESCRIPTION
To let developers customize the dashboard to their will, we must decouple:
- the collections that must be fetched for the dashboard
- the rendering to be done with these collections.

the `dashboardView()` logic doesn't allow that, so I propose this new syntax, quite similar to that of the new `menu()` configuration:

```js
admin.dashboard(nga.dashboard()
    .addCollection('posts', nga.collection(posts)
      .only({ published: true})
      .perPage(5) // limit the panel to the 5 latest posts
      .fields([
         nga.field('title').isDetailLink(true).map(truncate)
      ])
      .order()
     )
    .addCollection('tags', nga.collection(tags)
    .addCollection('comments', nga.collection(comments)
       .perPage(10)
       .fields([
           nga.field('id'),
           nga.field('name'),
           nga.field('published', 'boolean').label('Is published ?')
       ])
    )
   .template('....')
);
```

Changes to ng-admin are yet to be pushed, but this PR is BC.