### PR TITLE
[RFR] Add parameter in View.getReferences to filter on refreshDelay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+npm-debug.log

--- a/lib/Field/ReferenceField.js
+++ b/lib/Field/ReferenceField.js
@@ -12,7 +12,10 @@ class ReferenceField extends Field {
         this._sortDir = null;
         this._singleApiCall = false;
         this._detailLink = true;
-        this._refreshDelay = 500;
+        this._autocomplete = false;
+        this._autocompleteOptions = {
+            refreshDelay: 500
+        };
     }
 
     perPage(perPage) {
@@ -113,9 +116,15 @@ class ReferenceField extends Field {
         return this._targetEntity.name() + '_ListView.' + this.sortField();
     }
 
-    refreshDelay(refreshDelay) {
-        if (!arguments.length) return this._refreshDelay;
-        this._refreshDelay = refreshDelay;
+    autocomplete(autocomplete) {
+        if (!arguments.length) return this._autocomplete;
+        this._autocomplete = autocomplete;
+        return this;
+    }
+
+    autocompleteOptions(options) {
+        if (!arguments.length) return this._autocompleteOptions;
+        this._autocompleteOptions = options;
         return this;
     }
 }

--- a/lib/Field/ReferenceField.js
+++ b/lib/Field/ReferenceField.js
@@ -12,8 +12,8 @@ class ReferenceField extends Field {
         this._sortDir = null;
         this._singleApiCall = false;
         this._detailLink = true;
-        this._autocomplete = false;
-        this._autocompleteOptions = {
+        this._remoteComplete = false;
+        this._remoteCompleteOptions= {
             refreshDelay: 500
         };
     }
@@ -116,15 +116,16 @@ class ReferenceField extends Field {
         return this._targetEntity.name() + '_ListView.' + this.sortField();
     }
 
-    autocomplete(autocomplete) {
-        if (!arguments.length) return this._autocomplete;
-        this._autocomplete = autocomplete;
+    remoteComplete(remoteComplete, options) {
+        if (!arguments.length) return this._remoteComplete;
+        this._remoteComplete = remoteComplete;
+        this._remoteCompleteOptions = options;
         return this;
     }
 
-    autocompleteOptions(options) {
-        if (!arguments.length) return this._autocompleteOptions;
-        this._autocompleteOptions = options;
+    remoteCompleteOptions(options) {
+        if (!arguments.length) return this._remoteCompleteOptions;
+        this._remoteCompleteOptions = options;
         return this;
     }
 }

--- a/lib/Queries/ReadQueries.js
+++ b/lib/Queries/ReadQueries.js
@@ -347,7 +347,18 @@ class ReadQueries extends Queries {
         }
 
         return this._promisesResolver.allEvenFailed(calls)
-            .then(responses => responses.map(r => r.result) ); // @TODO: handle errors
+            .then(responses => {
+                var records = [];
+                for (let response of responses) {
+                    if (response.status == 'error') { // skip failed responses
+                        continue;
+                    }
+
+                    records.push(response.result);
+                }
+
+                return records;
+            });
     }
 }
 

--- a/lib/Queries/ReadQueries.js
+++ b/lib/Queries/ReadQueries.js
@@ -333,6 +333,22 @@ class ReadQueries extends Queries {
                 return entries;
             });
     }
+
+    getRecordsByIds(entity, ids) {
+        if (!ids || !ids.length) {
+            return this._promisesResolver.empty();
+        }
+
+        let getOne = this.getOne.bind(this),
+            calls = [];
+
+        for (let id of ids) {
+            calls.push(getOne(entity, 'listView', id, entity.identifier().name()));
+        }
+
+        return this._promisesResolver.allEvenFailed(calls)
+            .then(responses => responses.map(r => r.result) ); // @TODO: handle errors
+    }
 }
 
 export default ReadQueries;

--- a/lib/View/ListView.js
+++ b/lib/View/ListView.js
@@ -100,15 +100,15 @@ class ListView extends View {
         return this;
     }
 
-    getFilterReferences(withRefreshDelay) {
+    getFilterReferences(withRemoteComplete) {
         let result = {};
         let lists = this._filters.filter(f => f.type() === 'reference');
 
         var filterFunction = null;
-        if (withRefreshDelay === true) {
-            filterFunction = f => f.autocompleteOptions().refreshDelay > 0;
-        } else if (withRefreshDelay === false) {
-            filterFunction = f => !f.autocompleteOptions().refreshDelay;
+        if (withRemoteComplete === true) {
+            filterFunction = f => f.remoteComplete();
+        } else if (withRemoteComplete === false) {
+            filterFunction = f => !f.remoteComplete();
         }
 
         if (filterFunction !== null) {

--- a/lib/View/ListView.js
+++ b/lib/View/ListView.js
@@ -100,9 +100,21 @@ class ListView extends View {
         return this;
     }
 
-    getFilterReferences() {
+    getFilterReferences(withRefreshDelay) {
         let result = {};
         let lists = this._filters.filter(f => f.type() === 'reference');
+
+        var filterFunction = null;
+        if (withRefreshDelay === true) {
+            filterFunction = f => f.refreshDelay() > 0;
+        } else if (withRefreshDelay === false) {
+            filterFunction = f => f.refreshDelay() === null;
+        }
+
+        if (filterFunction !== null) {
+            lists = lists.filter(filterFunction);
+        }
+
         for (let i = 0, c = lists.length ; i < c ; i++) {
             let list = lists[i];
             result[list.name()] = list;

--- a/lib/View/ListView.js
+++ b/lib/View/ListView.js
@@ -106,9 +106,9 @@ class ListView extends View {
 
         var filterFunction = null;
         if (withRefreshDelay === true) {
-            filterFunction = f => f.refreshDelay() > 0;
+            filterFunction = f => f.autocompleteOptions().refreshDelay > 0;
         } else if (withRefreshDelay === false) {
-            filterFunction = f => f.refreshDelay() === null;
+            filterFunction = f => !f.autocompleteOptions().refreshDelay;
         }
 
         if (filterFunction !== null) {

--- a/lib/View/View.js
+++ b/lib/View/View.js
@@ -166,9 +166,9 @@ class View {
 
         var filterFunction = null;
         if (withRefreshDelay === true) {
-            filterFunction = f => f.refreshDelay() > 0;
+            filterFunction = f => f.autocompleteOptions().refreshDelay > 0;
         } else if (withRefreshDelay === false) {
-            filterFunction = f => f.refreshDelay() === null;
+            filterFunction = f => !f.autocompleteOptions().refreshDelay;
         }
 
         if (filterFunction !== null) {

--- a/lib/View/View.js
+++ b/lib/View/View.js
@@ -160,14 +160,14 @@ class View {
         return this;
     }
 
-    getReferences(withRefreshDelay) {
+    getReferences(withRemoteComplete) {
         let result = {};
         let lists = this._fields.filter(f => f.type() === 'reference' || f.type() === 'reference_many');
 
         var filterFunction = null;
-        if (withRefreshDelay === true) {
+        if (withRemoteComplete === true) {
             filterFunction = f => f.remoteComplete();
-        } else if (withRefreshDelay === false) {
+        } else if (withRemoteComplete === false) {
             filterFunction = f => !f.remoteComplete();
         }
 
@@ -183,12 +183,12 @@ class View {
         return result;
     }
 
-    getNonOptimizedReferences(withRefreshDelay) {
-        return this._getReferencesByOptimizationType(false, withRefreshDelay);
+    getNonOptimizedReferences(withRemoteComplete) {
+        return this._getReferencesByOptimizationType(false, withRemoteComplete);
     }
 
-    getOptimizedReferences(withRefreshDelay) {
-        return this._getReferencesByOptimizationType(true, withRefreshDelay);
+    getOptimizedReferences(withRemoteComplete) {
+        return this._getReferencesByOptimizationType(true, withRemoteComplete);
     }
 
     getReferencedLists() {
@@ -262,13 +262,13 @@ class View {
 
     /**
      * @param {Boolean} optimized
-     * @param {Boolean} withRefreshDelay
+     * @param {Boolean} withRemoteComplete
      * @returns {[Reference]}
      * @private
      */
-    _getReferencesByOptimizationType(optimized=true, withRefreshDelay=null) {
+    _getReferencesByOptimizationType(optimized=true, withRemoteComplete=null) {
         let result = {},
-            references = this.getReferences(withRefreshDelay);
+            references = this.getReferences(withRemoteComplete);
 
         for (let i in references) {
             let reference = references[i];

--- a/lib/View/View.js
+++ b/lib/View/View.js
@@ -160,9 +160,21 @@ class View {
         return this;
     }
 
-    getReferences() {
+    getReferences(withRefreshDelay) {
         let result = {};
         let lists = this._fields.filter(f => f.type() === 'reference' || f.type() === 'reference_many');
+
+        var filterFunction = null;
+        if (withRefreshDelay === true) {
+            filterFunction = f => f.refreshDelay() > 0;
+        } else if (withRefreshDelay === false) {
+            filterFunction = f => f.refreshDelay() === null;
+        }
+
+        if (filterFunction !== null) {
+            lists = lists.filter(filterFunction);
+        }
+
         for (let i = 0, c = lists.length ; i < c ; i++) {
             let list = lists[i];
             result[list.name()] = list;

--- a/lib/View/View.js
+++ b/lib/View/View.js
@@ -166,9 +166,9 @@ class View {
 
         var filterFunction = null;
         if (withRefreshDelay === true) {
-            filterFunction = f => f.autocompleteOptions().refreshDelay > 0;
+            filterFunction = f => f.remoteComplete();
         } else if (withRefreshDelay === false) {
-            filterFunction = f => !f.autocompleteOptions().refreshDelay;
+            filterFunction = f => !f.remoteComplete();
         }
 
         if (filterFunction !== null) {

--- a/lib/View/View.js
+++ b/lib/View/View.js
@@ -183,12 +183,12 @@ class View {
         return result;
     }
 
-    getNonOptimizedReferences() {
-        return this._getReferencesByOptimizationType(false);
+    getNonOptimizedReferences(withRefreshDelay) {
+        return this._getReferencesByOptimizationType(false, withRefreshDelay);
     }
 
-    getOptimizedReferences() {
-        return this._getReferencesByOptimizationType(true);
+    getOptimizedReferences(withRefreshDelay) {
+        return this._getReferencesByOptimizationType(true, withRefreshDelay);
     }
 
     getReferencedLists() {
@@ -261,14 +261,14 @@ class View {
     }
 
     /**
-     *
      * @param {Boolean} optimized
+     * @param {Boolean} withRefreshDelay
      * @returns {[Reference]}
      * @private
      */
-    _getReferencesByOptimizationType(optimized=true) {
+    _getReferencesByOptimizationType(optimized=true, withRefreshDelay=null) {
         let result = {},
-            references = this.getReferences();
+            references = this.getReferences(withRefreshDelay);
 
         for (let i in references) {
             let reference = references[i];

--- a/tests/lib/Queries/ReadQueriesTest.js
+++ b/tests/lib/Queries/ReadQueriesTest.js
@@ -262,4 +262,30 @@ describe('ReadQueries', () => {
             getRawValuesMock.restore();
         })
     });
+
+
+    describe('getRecordsByIds', function() {
+        it('should return a promise with array of all retrieved records', function(done) {
+            var spy = sinon.stub(readQueries, 'getOne', function(entity, viewType, identifierValue) {
+                return buildPromise({ result: identifierValue });
+            });
+
+            readQueries.getRecordsByIds(humanEntity, [1, 2]).then(function(records) {
+                assert.equal(spy.callCount, 2);
+                assert.equal(spy.args[0][2], 1);
+                assert.equal(spy.args[1][2], 2);
+                done();
+            });
+        });
+
+        it('should return promise with empty result if no ids are passed', function(done) {
+            var spy = sinon.spy(readQueries, 'getRawValues');
+
+            readQueries.getRecordsByIds(humanEntity, []).then(function(records) {
+                assert.equal(spy.called, false);
+                assert.equal(records, null);
+                done();
+            });
+        });
+    });
 });

--- a/tests/lib/View/ListViewTest.js
+++ b/tests/lib/View/ListViewTest.js
@@ -26,15 +26,10 @@ describe('ListView', function() {
             assert.deepEqual({category: category}, view.getFilterReferences());
         });
 
-        it('should return only filter reference with refresh delay if withRefreshDelay is true', function() {
+        it('should return only filter reference with refresh complete if withRemoteComplete is true', function() {
             var post = new Entity('post');
-            var category = new ReferenceField('category')
-                .autocomplete(true)
-                .autocompleteOptions({ refreshDelay: 500 });
-
-            var tags = new ReferenceManyField('tags')
-                .autocomplete(true)
-                .autocompleteOptions({ refreshDelay: null });
+            var category = new ReferenceField('category').remoteComplete(true);
+            var tags = new ReferenceManyField('tags').remoteComplete(false);
 
             var view = new ListView(post)
                 .fields([
@@ -48,14 +43,10 @@ describe('ListView', function() {
             assert.deepEqual({category: category}, view.getFilterReferences(true));
         });
 
-        it('should return only filter reference with no refresh delay if withRefreshDelay is false', function() {
+        it('should return only filter reference with no remote complete if withRemoteComplete is set to false', function() {
             var post = new Entity('post');
-            var category = new ReferenceField('category')
-                .autocomplete(true)
-                .autocompleteOptions({ refreshDelay: 500 });
-            var tags = new ReferenceManyField('tags')
-                .autocomplete(true)
-                .autocompleteOptions({ refreshDelay: null });
+            var category = new ReferenceField('category').remoteComplete(true);
+            var tags = new ReferenceManyField('tags').remoteComplete(false);
             var view = new ListView(post)
                 .fields([
                     new Field('title'),

--- a/tests/lib/View/ListViewTest.js
+++ b/tests/lib/View/ListViewTest.js
@@ -25,5 +25,37 @@ describe('ListView', function() {
 
             assert.deepEqual({category: category}, view.getFilterReferences());
         });
+
+        it('should return only filter reference with refresh delay if withRefreshDelay is true', function() {
+            var post = new Entity('post');
+            var category = new ReferenceField('category').refreshDelay(500);
+            var tags = new ReferenceManyField('tags').refreshDelay(null);
+            var view = new ListView(post)
+                .fields([
+                    new Field('title'),
+                    tags
+                ])
+                .filters([
+                    category
+                ]);
+
+            assert.deepEqual({category: category}, view.getFilterReferences(true));
+        });
+
+        it('should return only filter reference with no refresh delay if withRefreshDelay is false', function() {
+            var post = new Entity('post');
+            var category = new ReferenceField('category').refreshDelay(500);
+            var tags = new ReferenceManyField('tags').refreshDelay(null);
+            var view = new ListView(post)
+                .fields([
+                    new Field('title'),
+                    tags
+                ])
+                .filters([
+                    category
+                ]);
+
+            assert.deepEqual({ tags: tags }, view.getReferences(false));
+        });
     });
 });

--- a/tests/lib/View/ListViewTest.js
+++ b/tests/lib/View/ListViewTest.js
@@ -28,8 +28,14 @@ describe('ListView', function() {
 
         it('should return only filter reference with refresh delay if withRefreshDelay is true', function() {
             var post = new Entity('post');
-            var category = new ReferenceField('category').refreshDelay(500);
-            var tags = new ReferenceManyField('tags').refreshDelay(null);
+            var category = new ReferenceField('category')
+                .autocomplete(true)
+                .autocompleteOptions({ refreshDelay: 500 });
+
+            var tags = new ReferenceManyField('tags')
+                .autocomplete(true)
+                .autocompleteOptions({ refreshDelay: null });
+
             var view = new ListView(post)
                 .fields([
                     new Field('title'),
@@ -44,8 +50,12 @@ describe('ListView', function() {
 
         it('should return only filter reference with no refresh delay if withRefreshDelay is false', function() {
             var post = new Entity('post');
-            var category = new ReferenceField('category').refreshDelay(500);
-            var tags = new ReferenceManyField('tags').refreshDelay(null);
+            var category = new ReferenceField('category')
+                .autocomplete(true)
+                .autocompleteOptions({ refreshDelay: 500 });
+            var tags = new ReferenceManyField('tags')
+                .autocomplete(true)
+                .autocompleteOptions({ refreshDelay: null });
             var view = new ListView(post)
                 .fields([
                     new Field('title'),

--- a/tests/lib/View/ViewTest.js
+++ b/tests/lib/View/ViewTest.js
@@ -56,8 +56,12 @@ describe('View', function() {
 
         it('should return only reference with refresh delay if withRefreshDelay is true', function() {
             var post = new Entity('post');
-            var category = new ReferenceField('category').refreshDelay(200);
-            var tags = new ReferenceManyField('tags').refreshDelay(null);
+            var category = new ReferenceField('category')
+                .autocomplete(true)
+                .autocompleteOptions({ refreshDelay: 200 });
+            var tags = new ReferenceManyField('tags')
+                .autocomplete(true)
+                .autocompleteOptions({ refreshDelay: null });
             var view = new View(post).fields([
                 new Field('title'),
                 category,
@@ -69,8 +73,12 @@ describe('View', function() {
 
         it('should return only reference with no refresh delay if withRefreshDelay is false', function() {
             var post = new Entity('post');
-            var category = new ReferenceField('category').refreshDelay(200);
-            var tags = new ReferenceManyField('tags').refreshDelay(null);
+            var category = new ReferenceField('category')
+                .autocomplete(true)
+                .autocompleteOptions({ refreshDelay: 200 });
+            var tags = new ReferenceManyField('tags')
+                .autocomplete(true)
+                .autocompleteOptions({ refreshDelay: null });
             var view = new View(post).fields([
                 new Field('title'),
                 category,

--- a/tests/lib/View/ViewTest.js
+++ b/tests/lib/View/ViewTest.js
@@ -53,6 +53,32 @@ describe('View', function() {
 
             assert.deepEqual({category: category, tags: tags}, view.getReferences());
         });
+
+        it('should return only reference with refresh delay if withRefreshDelay is true', function() {
+            var post = new Entity('post');
+            var category = new ReferenceField('category').refreshDelay(200);
+            var tags = new ReferenceManyField('tags').refreshDelay(null);
+            var view = new View(post).fields([
+                new Field('title'),
+                category,
+                tags
+            ]);
+
+            assert.deepEqual({ category: category }, view.getReferences(true));
+        });
+
+        it('should return only reference with no refresh delay if withRefreshDelay is false', function() {
+            var post = new Entity('post');
+            var category = new ReferenceField('category').refreshDelay(200);
+            var tags = new ReferenceManyField('tags').refreshDelay(null);
+            var view = new View(post).fields([
+                new Field('title'),
+                category,
+                tags
+            ]);
+
+            assert.deepEqual({ tags: tags }, view.getReferences(false));
+        });
     });
 
     describe('addField()', function() {

--- a/tests/lib/View/ViewTest.js
+++ b/tests/lib/View/ViewTest.js
@@ -54,14 +54,10 @@ describe('View', function() {
             assert.deepEqual({category: category, tags: tags}, view.getReferences());
         });
 
-        it('should return only reference with refresh delay if withRefreshDelay is true', function() {
+        it('should return only reference with remote complete if withRemoteComplete is true', function() {
             var post = new Entity('post');
-            var category = new ReferenceField('category')
-                .autocomplete(true)
-                .autocompleteOptions({ refreshDelay: 200 });
-            var tags = new ReferenceManyField('tags')
-                .autocomplete(true)
-                .autocompleteOptions({ refreshDelay: null });
+            var category = new ReferenceField('category').remoteComplete(true);
+            var tags = new ReferenceManyField('tags').remoteComplete(false);
             var view = new View(post).fields([
                 new Field('title'),
                 category,
@@ -71,14 +67,10 @@ describe('View', function() {
             assert.deepEqual({ category: category }, view.getReferences(true));
         });
 
-        it('should return only reference with no refresh delay if withRefreshDelay is false', function() {
+        it('should return only reference with no remote complete if withRemoteComplete is false', function() {
             var post = new Entity('post');
-            var category = new ReferenceField('category')
-                .autocomplete(true)
-                .autocompleteOptions({ refreshDelay: 200 });
-            var tags = new ReferenceManyField('tags')
-                .autocomplete(true)
-                .autocompleteOptions({ refreshDelay: null });
+            var category = new ReferenceField('category').remoteComplete(true);
+            var tags = new ReferenceManyField('tags').remoteComplete(false);
             var view = new View(post).fields([
                 new Field('title'),
                 category,

--- a/tests/mock/PromisesResolver.js
+++ b/tests/mock/PromisesResolver.js
@@ -2,7 +2,8 @@
 import buildPromise from "./mixins";
 
 var PromisesResolver = {
-    allEvenFailed: function() { return buildPromise([]); }
+    allEvenFailed: function() { return buildPromise([]); },
+    empty: function() { return buildPromise(); }
 };
 
 export default PromisesResolver;


### PR DESCRIPTION
Useful to prevent from doing an extra request at route resolving on ng-admin (see https://github.com/marmelab/ng-admin/pull/508).