### PR TITLE
[RFR] set singleApiCall to batchDelete view for deleting in a single call

### DIFF
--- a/lib/Queries/WriteQueries.js
+++ b/lib/Queries/WriteQueries.js
@@ -49,20 +49,48 @@ class WriteQueries extends Queries {
     }
 
     /**
+     * Delete a batch of entity in a single call
+     * Delete the data to the API
+     *
+     * @param {String} view      the formView related to the entity
+     * @param {*}      entityIds the entities ids
+     *
+     * @returns {promise}
+     */
+    deleteMultiple(view, entityIds) {
+        let filterValues = view.getSingleApiCall(entityIds);
+
+        let params = {};
+        params._filters = {};
+        let filterName;
+        for (filterName in filterValues) {
+            params._filters[filterName] = filterValues[filterName];
+        }
+
+        return this._restWrapper
+            .deleteAll(view.entity.name(), this._application.getRouteFor(view.entity, view.getUrl(), view.type, null, view.identifier()), params);
+    }
+
+    /**
      * Delete a batch of entity
      * Delete the data to the API
      *
-     * @param {String} view     the formView related to the entity
+     * @param {String} view      the formView related to the entity
      * @param {*}      entityIds the entities ids
      *
      * @returns {promise}
      */
     batchDelete(view, entityIds) {
-        let deleteOne = this.deleteOne.bind(this)
-        let promises = entityIds.map(function (id) {
-            return deleteOne(view, id);
-        });
-
+        let promises;
+        if (view.hasSingleApiCall()) {
+            let deleteMultiple = this.deleteMultiple.bind(this);
+            promises = [deleteMultiple(view, entityIds)]
+        } else {
+            let deleteOne = this.deleteOne.bind(this)
+            promises = entityIds.map(function (id) {
+                return deleteOne(view, id);
+            });
+        }
         return this._promisesResolver.allEvenFailed(promises);
     }
 }

--- a/lib/View/BatchDeleteView.js
+++ b/lib/View/BatchDeleteView.js
@@ -1,11 +1,27 @@
 import View from './View';
 
 class BatchDeleteView extends View {
+
     constructor(name) {
         super(name);
 
         this._type = 'BatchDeleteView';
         this._enabled = true;
+        this._singleApiCall = false;
+    }
+
+    singleApiCall(singleApiCall) {
+        if (!arguments.length) return this._singleApiCall;
+        this._singleApiCall = singleApiCall;
+        return this;
+    }
+
+    hasSingleApiCall() {
+        return typeof this._singleApiCall === 'function';
+    }
+
+    getSingleApiCall(identifiers) {
+        return this.hasSingleApiCall() ? this._singleApiCall(identifiers) : this._singleApiCall;
     }
 }
 


### PR DESCRIPTION
We need, in 1859 project, to be able to `batch delete` multiple objects in a single call. 
With this PR, we will be able to set a `singleApiCall` function to the `BatchDeleteView` and then, create a single request to delete objects in API (with a DELETE request on /objects?id[]=1&id[]=2&id[]=5)