### PR TITLE
[RFR] Menu enabled fix

### DIFF
--- a/lib/Entity/Entity.js
+++ b/lib/Entity/Entity.js
@@ -26,7 +26,6 @@ class Entity {
         this._createMethod = null; // manually set the HTTP-method for create operation, defaults to post
         this._updateMethod = null; // manually set the HTTP-method for update operation, defaults to put
 
-
         this._initViews();
     }
 

--- a/lib/View/MenuView.js
+++ b/lib/View/MenuView.js
@@ -5,10 +5,11 @@ class MenuView extends View {
         super(name);
         this._type = 'MenuView';
         this._icon = null;
+        this._enabled = true;
     }
 
     get enabled() {
-        return this._enabled || this.entity.views['ListView'].enabled;
+        return this._enabled && this.entity.views['ListView'].enabled;
     }
 
     icon() {

--- a/lib/View/View.js
+++ b/lib/View/View.js
@@ -64,16 +64,10 @@ class View {
         return this.enabled;
     }
 
-    /**
-     * @deprecated Use getter "entity" instead
-     */
     getEntity() {
         return this.entity;
     }
 
-    /**
-     * @deprecated Specify entity at view creation or use "entity" setter instead
-     */
     setEntity(entity) {
         this.entity = entity;
         if (!this._name) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-config",
-  "version": "0.2.3",
+  "version": "0.2.2",
   "private": false,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-config",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": false,
   "repository": {
     "type": "git",

--- a/tests/lib/View/MenuViewTest.js
+++ b/tests/lib/View/MenuViewTest.js
@@ -4,6 +4,30 @@ import Entity from "../../../lib/Entity/Entity";
 import MenuView from "../../../lib/View/MenuView";
 
 describe('MenuView', function() {
+    describe('enabled', function() {
+        var entity, menuView;
+        beforeEach(function() {
+            entity = new Entity('post');
+            entity.listView().enable();
+
+            menuView = entity.menuView().enable();
+        });
+
+        it('should be considered as enable if enabled AND if related list view is enabled', function() {
+            assert.equal(menuView.enabled, true);
+        });
+
+        it('should not be enabled if no related list view is enabled', function() {
+            entity.listView().disable();
+            assert.equal(menuView.enabled, false);
+        });
+
+        it('should not be enabled if disabled', function() {
+            menuView.disable();
+            assert.equal(menuView.enabled, false);
+        });
+    });
+
     describe('icon', function() {
         it('should default to list glyphicon', function() {
             var view = new MenuView(new Entity('post'));


### PR DESCRIPTION
This PR is related to a [discussion on ng-admin](https://github.com/marmelab/ng-admin/issues/533).

Currently, we display a menu item either if it is enabled or if there is a related list view. Thus, the following code would cause some inconsistencies:

``` js
var entity = new Entity('post');
entity.listView().enable();
entity.menuView().disable();
```

User would expect to not see the menu item, yet it still appears, as list view is enabled.

This PR fixes this:

* if menu view is disabled, we don't display it in the menu.
* if menu view is enabled, but if list view is disabled, disable the menu, as it would point to nowhere.

For BC reasons, I had to enable by default the menu view.

Beyond this PR, I wonder if we shouldn't let the reponsibility of menu item display to the developer. If he disabled the list view, he would get a 404, and then he would have to fix it. 