### PR TITLE
[RFR] Use searchQuery option for remoteComplete

### DIFF
--- a/lib/Field/ReferenceField.js
+++ b/lib/Field/ReferenceField.js
@@ -51,12 +51,8 @@ class ReferenceField extends Field {
      *        published: true
      *     });
      *     // related API call will be /posts/:id?published=true
-     *     // if the permanent filter depends on the current query string, use a function
-     *     nga.field('post_id', 'reference').permanentFilters(function(search) {
-     *        return { published: true }
-     *     });
      *
-     * @param {Object|Function} filters list of filters to apply to the call
+     * @param {Object} filters list of filters to apply to the call
      */
     permanentFilters(filters) {
         if (!arguments.length) {
@@ -69,7 +65,7 @@ class ReferenceField extends Field {
     }
 
     /**
-     * @deprecated use permanentFilters() unstead
+     * @deprecated use permanentFilters() instead
      */
     filters(filters) {
         console.warn('ReferenceField.filters() is deprecated, please use ReferenceField.permanentFilters() instead');
@@ -138,10 +134,33 @@ class ReferenceField extends Field {
         return this._targetEntity.name() + '_ListView.' + this.sortField();
     }
 
+    /**
+     * Enable autocompletion using REST API for choices.
+     *
+     * Available options are:
+     *
+     * * `refreshDelay`: minimal delay between two API calls in milliseconds. By default: 500.
+     * * `searchQuery`: a function returning the parameters to add to the query string basd on the input string.
+     *
+     *       new ReferenceField('authors')
+     *           .targetEntity(author)
+     *           .targetField(new Field('name'))
+     *           .remoteComplete(true, {
+     *               refreshDelay: 300,
+     *               // populate choices from the response of GET /tags?q=XXX
+     *               searchQuery: function(search) { return { q: search }; }
+     *           })
+     *           .perPage(10) // limit the number of results to 10
+     *
+     * @param {Boolean} remoteComplete true to enable remote complete. False by default
+     * @param {Object} options Remote completion options (optional)
+     */
     remoteComplete(remoteComplete, options) {
         if (!arguments.length) return this._remoteComplete;
         this._remoteComplete = remoteComplete;
-        this._remoteCompleteOptions = options;
+        if (options) {
+            this.remoteCompleteOptions(options);
+        }
         return this;
     }
 

--- a/lib/Queries/ReadQueries.js
+++ b/lib/Queries/ReadQueries.js
@@ -196,7 +196,28 @@ class ReadQueries extends Queries {
             let reference = references[i];
             let targetEntity = reference.targetEntity();
 
-            let permanentFilters = reference.permanentFilters();
+            const permanentFilters = reference.permanentFilters();
+            let filterValues = permanentFilters || {};
+
+            if (typeof(permanentFilters) === 'function') {
+                console.warn('Reference.permanentFilters() called with a function is deprecated. Use the searchQuery option for remoteComplete() instead');
+                filterValues = permanentFilters(search);
+            }
+
+            if (search) {
+                // remote complete situation
+                let options = reference.remoteCompleteOptions();
+                if (options.searchQuery) {
+                    let filterValuesFromRemoteComplete = options.searchQuery(search);
+                    Object.keys(filterValuesFromRemoteComplete).forEach(key => {
+                        filterValues[key] = filterValuesFromRemoteComplete[key];
+                    })
+                } else {
+                    // by default, filter the list by the referenceField name
+                    filterValues[reference.targetField().name()] = search;
+                }
+            }
+
             let filterFields = {};
             filterFields[reference.name()] = reference;
 
@@ -206,7 +227,7 @@ class ReadQueries extends Queries {
                 'listView',
                 1,
                 reference.perPage(),
-                typeof(permanentFilters) === 'function' ? permanentFilters(search) : permanentFilters,
+                filterValues,
                 filterFields,
                 reference.getSortFieldName(),
                 reference.sortDir()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-config",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "private": false,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Using a generic 'filter()' or 'permanentFilter()' method for specifying
the remote complete search query didn't make sense.