### PR TITLE
[RFR] Remove need for a Symbol shim

### DIFF
--- a/lib/Queries/ReadQueries.js
+++ b/lib/Queries/ReadQueries.js
@@ -372,26 +372,10 @@ class ReadQueries extends Queries {
             return this._promisesResolver.empty();
         }
 
-        let getOne = this.getOne.bind(this),
-            calls = [];
-
-        for (let id of ids) {
-            calls.push(getOne(entity, 'listView', id, entity.identifier().name()));
-        }
+        let calls = ids.map(id => this.getOne(entity, 'listView', id, entity.identifier().name()));
 
         return this._promisesResolver.allEvenFailed(calls)
-            .then(responses => {
-                var records = [];
-                for (let response of responses) {
-                    if (response.status == 'error') { // skip failed responses
-                        continue;
-                    }
-
-                    records.push(response.result);
-                }
-
-                return records;
-            });
+            .then(responses => responses.filter(r => r.status != 'error').map(r => r.result));
     }
 }
 


### PR DESCRIPTION
Babel transpiles for...of to ES6 Symbol, which is not supported on Safari. Until we really need for...of, I refactored the code to avoid adding the shim.

Closes https://github.com/marmelab/ng-admin/issues/610