### PR TITLE
[RFR] Allow a field not mapped by a REST value to use map()

### DIFF
--- a/lib/Entry.js
+++ b/lib/Entry.js
@@ -41,9 +41,7 @@ class Entry {
 
         fields.forEach(field => {
             let fieldName = field.name();
-            if (fieldName in values) {
-                values[fieldName] = field.getMappedValue(values[fieldName], values);
-            }
+            values[fieldName] = field.getMappedValue(values[fieldName], values);
         });
 
         return new Entry(entityName, values, values[identifierName]);

--- a/tests/lib/EntryTest.js
+++ b/tests/lib/EntryTest.js
@@ -49,6 +49,17 @@ describe('Entry', function() {
             }, mappedEntry.values);
         });
 
+        it('should map even if the value is absent', () => {
+            var fields = [new Field('foo').map((v,e) => e.tags.join(' '))];
+            var mappedEntry = Entry.createFromRest({
+                tags: [1, 2, 3, 4]
+            }, fields);
+            assert.deepEqual({
+                foo: '1 2 3 4',
+                tags: [1, 2, 3, 4]
+            }, mappedEntry.values)
+        });
+
         it('should set as identifierValue value for identifier field', () => {
             var mappedEntry = Entry.createFromRest({ id: 1 });
             assert.equal(1, mappedEntry.identifierValue);


### PR DESCRIPTION
```js
            var fields = [new Field('foo').map((v,e) => e.tags.join(' '))];
            var mappedEntry = Entry.createFromRest({
                tags: [1, 2, 3, 4]
            }, fields);
            assert.deepEqual({
                foo: '1 2 3 4',
                tags: [1, 2, 3, 4]
            }, mappedEntry.values)
```