### PR TITLE
Introducing fieldsets and rows

### DIFF
--- a/lib/Factory.js
+++ b/lib/Factory.js
@@ -24,6 +24,8 @@ import ReferenceManyField from "./Field/ReferenceManyField";
 import TemplateField from "./Field/TemplateField";
 import TextField from "./Field/TextField";
 import WysiwygField from "./Field/WysiwygField";
+import FieldSet from "./Field/FieldSet";
+import RowField from "./Field/RowField";
 
 import Menu from './Menu/Menu';
 import Collection from './Collection';
@@ -121,6 +123,8 @@ class Factory {
         this.registerFieldType('template', TemplateField);
         this.registerFieldType('text', TextField);
         this.registerFieldType('wysiwyg', WysiwygField);
+        this.registerFieldType('fieldset', FieldSet);
+        this.registerFieldType('row', RowField);
     }
 }
 

--- a/lib/Field/Field.js
+++ b/lib/Field/Field.js
@@ -19,6 +19,7 @@ class Field {
         this._flattenable = true;
         this.dashboard = true;
         this.list = true;
+        this._labelCssClasses = null;
     }
 
     label() {
@@ -143,6 +144,18 @@ class Field {
     cssClasses(classes) {
         if (!arguments.length) return this._cssClasses;
         this._cssClasses = classes;
+        return this;
+    }
+
+    labelCssClasses(classes) {
+        if (!arguments.length){
+            if (this._labelCssClasses !== null) {
+                return this._labelCssClasses;
+            }
+
+            return 'col-sm-2 control-label';
+        }
+        this._labelCssClasses = classes;
         return this;
     }
 

--- a/lib/Field/FieldSet.js
+++ b/lib/Field/FieldSet.js
@@ -1,0 +1,56 @@
+'use strict';
+
+import Field from './Field';
+
+class FieldSet extends Field {
+    constructor(name) {
+        super(name);
+        this._type = 'fieldset';
+        this._rows = [];
+        this._cssClasses = ['grid-form'];
+        this._span = null;
+    }
+
+    getReferences() {
+        let out = [];
+        for (var i in this._rows) {
+            for (var j in this._rows[i]._fields) {
+                var f = this._rows[i]._fields[j];
+                if (f.type() === 'reference' || f.type() === 'reference_many') {
+                    out.push(f);
+                }
+            }
+        }
+        return out;
+    }
+
+    isFieldset() {
+        return true;
+    }
+
+    span() {
+        if (!arguments.length) {
+            return this._span || this._rows.length || 1;
+        }
+
+        this._span = arguments[0];
+        return this;
+    }
+
+    rows(rows) {
+        if (!arguments.length) {
+            return this._rows;
+        }
+
+        for (var i in rows) {
+            if (rows[i].type() !== 'row') {
+                throw "fieldset expects rows to be row type";
+            }
+        }
+
+        this._rows = rows;
+        return this;
+    }
+}
+
+export default FieldSet;

--- a/lib/Field/RowField.js
+++ b/lib/Field/RowField.js
@@ -1,0 +1,55 @@
+'use strict';
+
+import Field from './Field';
+
+class RowField extends Field {
+    constructor(name) {
+        super(name);
+        this._type = 'row';
+        this._span = null;
+        this._fields = [];
+    }
+
+    span() {
+        if (!arguments.length) {
+            return this._span || this._fields.length || 1;
+        }
+        this._span = arguments[0];
+        return this;
+    }
+
+    editCssSpanClass(field){
+        if (field.attributes.editSpan) {
+            return 'col-md-' + field.attributes().editSpan;
+        }
+
+        return this.cssSpanClass(field)
+    }
+
+    cssSpanClass(field) {
+        if (field.attributes().span) {
+            return 'col-md-' + field.attributes().span;
+        }
+        var span = this._span || this._fields.length;
+        return 'col-md-' + (12/span);
+    }
+
+    fields() {
+        if (!arguments.length) {
+            return this._fields;
+        }
+
+        this._fields = arguments[0];
+        for (var i in this._fields) {
+            var field = this._fields[i];
+            field.labelCssClasses('');
+            if (!field.cssClasses()) {
+                field.cssClasses('row-field');
+            }
+        }
+
+        return this;
+    }
+}
+
+export default RowField;

--- a/lib/View/View.js
+++ b/lib/View/View.js
@@ -164,6 +164,11 @@ class View {
     getReferences(withRemoteComplete) {
         let result = {};
         let lists = this._fields.filter(f => f.type() === 'reference' || f.type() === 'reference_many');
+        let fieldsets = this._fields.filter(f => f.type() === 'fieldset');
+        for (var i in fieldsets) {
+            let refs = fieldsets[i].getReferences();
+            lists = lists.concat(refs);
+        }
 
         var filterFunction = null;
         if (withRemoteComplete === true) {


### PR DESCRIPTION
In order to achieve a grid form layout like in the image we need field containers. Fieldsets will contain rows which then will contain fields.

Possible target:
![](https://cloud.githubusercontent.com/assets/99944/7720877/7a866532-fed2-11e4-9ac6-37fcf2d01d24.png)

Real example (with only 1 fieldset):
![gridform](https://cloud.githubusercontent.com/assets/545883/9645266/dc520a34-51a0-11e5-9417-9578721b610f.png)
