### PR TITLE
Made template fields non-flattenable

### DIFF
--- a/lib/Field/TemplateField.js
+++ b/lib/Field/TemplateField.js
@@ -5,6 +5,7 @@ class TemplateField extends Field {
         super(name);
         this._template = function() { return ''; };
         this._type = "template";
+        this._flattenable = false;
     }
 
     getTemplateValue(data) {


### PR DESCRIPTION
Since you would probably like to use the unchanged data you provide within a template field, this field should be set to non-flattenable to avoid confusion.