### PR TITLE
[RFR] Add ReadQuery.getOptimizedRecordsByIds() method and remove withRemoteComplete possible argument in ReferenceExtractor

### DIFF
--- a/lib/Field/ReferencedListField.js
+++ b/lib/Field/ReferencedListField.js
@@ -55,16 +55,16 @@ class ReferencedListField extends ReferenceField {
         return this;
     }
 
-    getReferences(withRemoteComplete) {
-        return ReferenceExtractor.getReferences(this._targetFields, withRemoteComplete);
+    getReferences() {
+        return ReferenceExtractor.getReferences(this._targetFields);
     }
 
-    getNonOptimizedReferences(withRemoteComplete) {
-        return ReferenceExtractor.getNonOptimizedReferences(this._targetFields, withRemoteComplete);
+    getNonOptimizedReferences() {
+        return ReferenceExtractor.getNonOptimizedReferences(this._targetFields);
     }
 
-    getOptimizedReferences(withRemoteComplete) {
-        return ReferenceExtractor.getOptimizedReferences(this._targetFields, withRemoteComplete);
+    getOptimizedReferences() {
+        return ReferenceExtractor.getOptimizedReferences(this._targetFields);
     }
 }
 

--- a/lib/Queries/ReadQueries.js
+++ b/lib/Queries/ReadQueries.js
@@ -399,6 +399,14 @@ class ReadQueries extends Queries {
         return this._promisesResolver.allEvenFailed(calls)
             .then(responses => responses.filter(r => r.status != 'error').map(r => r.result));
     }
+
+    getOptimizedRecordsByIds(entity, singleCallFilters) {
+        let getRawValues = this.getRawValues.bind(this);
+        const calls = [getRawValues(entity, entity.name() + '_ListView', 'listView', -1, null, singleCallFilters, {})];
+
+        return this._promisesResolver.allEvenFailed(calls)
+            .then(responses => responses.filter(r => r.status != 'error').map(r => r.result.data)[0]);
+    }
 }
 
 export default ReadQueries;

--- a/lib/Utils/ReferenceExtractor.js
+++ b/lib/Utils/ReferenceExtractor.js
@@ -3,23 +3,18 @@ export default {
     getReferencedLists(fields) {
         return this.indexByName(fields.filter(f => f.type() === 'referenced_list'));
     },
-    getReferences(fields, withRemoteComplete, optimized = null) {
+    getReferences(fields, optimized = null) {
         let references = fields.filter(f => f.type() === 'reference' || f.type() === 'reference_many');
-        if (withRemoteComplete === true) {
-            references = references.filter(r => r.remoteComplete());
-        } else if (withRemoteComplete === false) {
-            references = references.filter(r => !r.remoteComplete());
-        }
         if (optimized !== null) {
             references = references.filter(r => r.hasSingleApiCall() === optimized)
         }
         return this.indexByName(references);
     },
-    getNonOptimizedReferences(fields, withRemoteComplete) {
-        return this.getReferences(fields, withRemoteComplete, false);
+    getNonOptimizedReferences(fields) {
+        return this.getReferences(fields, false);
     },
-    getOptimizedReferences(fields, withRemoteComplete) {
-        return this.getReferences(fields, withRemoteComplete, true);
+    getOptimizedReferences(fields) {
+        return this.getReferences(fields, true);
     },
     indexByName(references) {
         return references.reduce((referencesByName, reference) => {

--- a/tests/lib/View/ViewTest.js
+++ b/tests/lib/View/ViewTest.js
@@ -53,32 +53,6 @@ describe('View', function() {
 
             assert.deepEqual({category: category, tags: tags}, view.getReferences());
         });
-
-        it('should return only reference with remote complete if withRemoteComplete is true', function() {
-            var post = new Entity('post');
-            var category = new ReferenceField('category').remoteComplete(true);
-            var tags = new ReferenceManyField('tags').remoteComplete(false);
-            var view = new View(post).fields([
-                new Field('title'),
-                category,
-                tags
-            ]);
-
-            assert.deepEqual({ category: category }, view.getReferences(true));
-        });
-
-        it('should return only reference with no remote complete if withRemoteComplete is false', function() {
-            var post = new Entity('post');
-            var category = new ReferenceField('category').remoteComplete(true);
-            var tags = new ReferenceManyField('tags').remoteComplete(false);
-            var view = new View(post).fields([
-                new Field('title'),
-                category,
-                tags
-            ]);
-
-            assert.deepEqual({ tags: tags }, view.getReferences(false));
-        });
     });
 
     describe('addField()', function() {


### PR DESCRIPTION
* [x] Allow to use `singleApiCall` for reference field
* [x] Do not filter references with `remoteComplete` field config as reference field must be lazy loaded