### PR TITLE
fix missing `entry` argument for transform()

### DIFF
--- a/lib/Entry.js
+++ b/lib/Entry.js
@@ -67,7 +67,7 @@ class Entry {
         fields.forEach(field => {
             let fieldName = field.name();
             if (fieldName in restEntry) {
-                restEntry[fieldName] = field.getTransformedValue(restEntry[fieldName])
+                restEntry[fieldName] = field.getTransformedValue(restEntry[fieldName], restEntry)
             }
         });
 

--- a/tests/lib/EntryTest.js
+++ b/tests/lib/EntryTest.js
@@ -111,20 +111,17 @@ describe('Entry', function() {
     });
 
     describe('transformToRest()', function() {
-        it('should provide both the value and entry when invoking the callback', (done) => {
+        it('should provide both the value and entry when invoking the callback', () => {
             var field = new Field('foo');
             field.defaultValue(2);
+
             var entry = Entry.createForFields([field]);
 
             field.transform((value, entry) => {
+                assert.equal(value, 2);
                 assert.deepEqual(entry, {foo: 2});
-                entry.bar = 1;
             });
-            field.transform((value, entry) => {
-                assert.deepEqual(entry, {foo: 2, bar: 1});
 
-                done();
-            });
             entry.transformToRest([field]);
         });
     });

--- a/tests/lib/EntryTest.js
+++ b/tests/lib/EntryTest.js
@@ -109,4 +109,23 @@ describe('Entry', function() {
             }, mappedEntry.values);
         })
     });
+
+    describe('transformToRest()', function() {
+        it('should provide both the value and entry when invoking the callback', (done) => {
+            var field = new Field('foo');
+            field.defaultValue(2);
+            var entry = Entry.createForFields([field]);
+
+            field.transform((value, entry) => {
+                assert.deepEqual(entry, {foo: 2});
+                entry.bar = 1;
+            });
+            field.transform((value, entry) => {
+                assert.deepEqual(entry, {foo: 2, bar: 1});
+
+                done();
+            });
+            entry.transformToRest([field]);
+        });
+    });
 });

--- a/tests/lib/Field/FieldTest.js
+++ b/tests/lib/Field/FieldTest.js
@@ -81,5 +81,4 @@ describe('Field', function() {
             assert.equal(field.getTemplateValue('John'), 'hello John !');
         });
     });
-
 });


### PR DESCRIPTION
The second argument to `transform()` was never passed. 

According to the [documentation](https://github.com/marmelab/ng-admin/blob/v0.9.1/doc/reference/Field.md#general-field-settings) that should be the entry