### PR TITLE
Fix an exception when cloneAndNest called with null nested params

### DIFF
--- a/lib/Utils/objectProperties.js
+++ b/lib/Utils/objectProperties.js
@@ -68,11 +68,13 @@ export function cloneAndNest(object) {
     return Object.keys(object).reduce((values, name) => {
         if (!object.hasOwnProperty(name)) return values;
         name.split('.').reduce((previous, current, index, list) => {
-            if (typeof previous[current] === 'undefined') previous[current] = {};
-            if (index < (list.length - 1)) {
-                return previous[current];
-            };
-            previous[current] = object[name];
+            if (previous != null) {
+                if (typeof previous[current] === 'undefined') previous[current] = {};
+                if (index < (list.length - 1)) {
+                    return previous[current];
+                };
+                previous[current] = object[name];
+            }
         }, values)
         return values;
     }, {})

--- a/tests/lib/Utils/objectPropertiesTest.js
+++ b/tests/lib/Utils/objectPropertiesTest.js
@@ -60,4 +60,7 @@ describe('cloneAndNest()', () => {
         assert.deepEqual(cloneAndNest({ a: 1, 'b.c': 2, 'd.e': 3, 'd.f.g': 4, 'd.f.h': 5 }),
                                       { a: 1, b: { c: 2 }, d: { e: 3, f: { g: 4, h: 5 } } })
     );
+    it('should not error on null nested objects', () =>
+        cloneAndNest({ a: null, 'a.b': null })
+    );
 });


### PR DESCRIPTION
This is an issue when trying to save an object configured with nested properties with a null values. For example the following field configuration nga.field('a.b', 'embedded_list') will throw an exception if the object to save is { a: null }.