### PR TITLE
Return input text if not a valid Date object.

### DIFF
--- a/lib/Field/DateField.js
+++ b/lib/Field/DateField.js
@@ -15,6 +15,7 @@ class DateField extends Field {
                 let dateString = date.toJSON();
                 return dateString ? dateString.substr(0,10) : null;
             }
+            return date;
         };
         this._type = "date";
     }


### PR DESCRIPTION
It fixes: marmelab/ng-admin/issues/816