### PR TITLE
Added singleton property to ``Entity``

### DIFF
--- a/lib/Entity/Entity.js
+++ b/lib/Entity/Entity.js
@@ -20,6 +20,7 @@ class Entity {
         this._label = null;
         this._identifierField = new Field("id");
         this._isReadOnly = false;
+        this._isSingleton = false;
         this._errorMessage = null;
         this._order = 0;
         this._url = null;
@@ -140,6 +141,21 @@ class Entity {
 
     get isReadOnly() {
         return this._isReadOnly;
+    }
+
+    singleton() {
+        this._isSingleton = true;
+
+        this._views["ListView"].disable();
+        this._views["CreateView"].disable();
+        this._views["DeleteView"].disable();
+        this._views["BatchDeleteView"].disable();
+
+        return this;
+    }
+
+    get isSingleton() {
+        return this._isSingleton;
     }
 
     getErrorMessage(response) {

--- a/lib/Menu/Menu.js
+++ b/lib/Menu/Menu.js
@@ -112,7 +112,11 @@ class Menu {
         }
         this.title(entity.label());
         this.active(path => path.indexOf(`/${entity.name()}/`) === 0 );
-        this.link(`/${entity.name()}/list`);
+        if (entity.isSingleton) {
+            this.link(`/${entity.name()}/edit`);
+        } else {
+            this.link(`/${entity.name()}/list`);
+        }
         // deprecated
         this.icon(entity.menuView().icon());
         return this;

--- a/tests/lib/Entity/EntityTest.js
+++ b/tests/lib/Entity/EntityTest.js
@@ -62,6 +62,42 @@ describe('Entity', function() {
             assert.equal(false, entity.deletionView().enabled);
         });
     });
+
+    describe('singleton()', function () {
+        var entity;
+
+        beforeEach(function() {
+            entity = new Entity('post');
+        });
+
+        it('should not be single by default', function() {
+            assert.equal(false, entity.isSingleton);
+        });
+
+        it('should set singleton attribute', function() {
+            entity.singleton();
+            assert.equal(true, entity.isSingleton);
+        });
+
+        it('should disable create, delete and list views', function() {
+            entity.singleton();
+            entity.views.DashboardView.enable();
+            entity.views.MenuView.enable();
+            entity.views.EditView.enable();
+            entity.views.ShowView.enable();
+            entity.views.ExportView.enable();
+
+            assert.equal(true, entity.menuView().enabled);
+            assert.equal(true, entity.dashboardView().enabled);
+            assert.equal(true, entity.editionView().enabled);
+            assert.equal(true, entity.showView().enabled);
+            assert.equal(true, entity.exportView().enabled);
+            assert.equal(false, entity.listView().enabled);
+            assert.equal(false, entity.creationView().enabled);
+            assert.equal(false, entity.deletionView().enabled);
+            assert.equal(false, entity.batchDeleteView().enabled);
+        });
+    });
     
     describe('createMethod', function() {
         it('should return given createMethod if already set', function() {

--- a/tests/lib/Menu/MenuTest.js
+++ b/tests/lib/Menu/MenuTest.js
@@ -96,6 +96,9 @@ describe('Menu', () => {
         it('should set link according to entity', () => {
             assert.equal('/comments/list', new Menu().populateFromEntity(new Entity('comments')).link());
         });
+        it('should set link to edit for singleton entity', () => {
+            assert.equal('/settings/edit', new Menu().populateFromEntity(new Entity('settings').singleton()).link());
+        });
         it('should set active function to entity', () => {
             let menu = new Menu().populateFromEntity(new Entity('comments'));
             assert.isTrue(menu.isActive('/comments/list'));


### PR DESCRIPTION
Added a ``singleton`` flag to an ``Entity`` to support singleton support in ``ng-admin``.

Setting to singleton removes the ability to list, create or delete. It also changes the menu item to go to "edit" instead of "list".