### PR TITLE
Add Field#condition

### DIFF
--- a/lib/Field/Field.js
+++ b/lib/Field/Field.js
@@ -11,6 +11,7 @@ class Field {
         this._transforms = [];
         this._attributes = {};
         this._cssClasses = null;
+        this._condition = { property: null, value: null },
         this._validation = { required: false, minlength : 0, maxlength : 99999 };
         this._defaultValue = null;
         this._editable = true;
@@ -162,6 +163,19 @@ class Field {
         }
 
         return this._cssClasses;
+    }
+
+    condition(property, value) {
+        if (!arguments.length) {
+            return this._condition;
+        }
+
+        if (property && value) {
+            this._condition.property = property;
+            this._condition.value = value;
+        }
+
+        return this;
     }
 
     validation(validation) {

--- a/tests/lib/Field/FieldTest.js
+++ b/tests/lib/Field/FieldTest.js
@@ -90,6 +90,17 @@ describe('Field', function() {
 
     });
 
+    describe('condition()', function() {
+        it('should have sensible defaults', function() {
+            assert.deepEqual(new Field().condition(), {property: null, value: null});
+        });
+
+        it('should allow to change condition settings', function() {
+            var field = new Field().condition("foo", "bar");
+            assert.deepEqual(field.condition(), {property: "foo", value: "bar"});
+        });
+    });
+
     describe('validation()', function() {
         it('should have sensible defaults', function() {
             assert.deepEqual(new Field().validation(), {required: false, minlength : 0, maxlength : 99999});


### PR DESCRIPTION
This will enable you to use the condition data to show or hide the field from the admin based on the conditions given.

I'm utilizing this to enable a feature I've created a PR to ng-admin for, see https://github.com/marmelab/ng-admin/pull/924.
