### PR TITLE
ng-admin/#1041 fix encoding of entity ids in REST URLs

### DIFF
--- a/lib/Application.js
+++ b/lib/Application.js
@@ -44,9 +44,9 @@ class Application {
 
         // If the view or the entity don't define the url, retrieve it from the baseURL of the entity or the app
         if (!url) {
-            url = baseApiUrl + entity.name();
+            url = baseApiUrl + encodeURIComponent(entity.name());
             if (identifierValue != null) {
-                url += '/' + identifierValue;
+                url += '/' + encodeURIComponent(identifierValue);
             }
         } else if (!/^(?:[a-z]+:)?\/\//.test(url)) {
             // Add baseUrl for relative URL

--- a/tests/lib/ApplicationTest.js
+++ b/tests/lib/ApplicationTest.js
@@ -88,7 +88,7 @@ describe('Application', function() {
             var application = new Application();
             var entity = new Entity('posts');
             entity.url(function(entityName, viewType, identifierValue) {
-                return '/bar/baz' + (identifierValue ? ('/' + identifierValue * 2) : '');
+                return '/bar/baz' + (identifierValue ? ('/' + encodeURIComponent(identifierValue * 2)) : '');
             });
             application.addEntity(entity);
             var view = entity.listView();
@@ -101,7 +101,7 @@ describe('Application', function() {
             application.baseApiUrl('/foo/');
             var entity = new Entity('posts');
             entity.url(function(entityName, viewType, identifierValue) {
-                return 'bar/baz' + (identifierValue ? ('/' + identifierValue) : '');
+                return 'bar/baz' + (identifierValue ? ('/' + encodeURIComponent(identifierValue)) : '');
             });
             application.addEntity(entity);
             var view = entity.listView();
@@ -114,7 +114,7 @@ describe('Application', function() {
             application.baseApiUrl('/foo/');
             var entity = new Entity('posts');
             entity.url(function(entityName, viewType, identifierValue) {
-                return 'http://bar/baz' + (identifierValue ? ('/' + identifierValue) : '');
+                return 'http://bar/baz' + (identifierValue ? ('/' + encodeURIComponent(identifierValue)) : '');
             });
             application.addEntity(entity);
             var view = entity.listView();
@@ -186,7 +186,7 @@ describe('Application', function() {
             app.baseApiUrl('http://api.local');
 
             view.url(function (entityId) {
-                return '/post/:' + entityId;
+                return '/post/:' + encodeURIComponent(entityId);
             });
 
             assert.equal(app.getRouteFor(entity1, view.getUrl(1), view.type, 1, view.identifier()), 'http://api.local/post/:1');
@@ -200,7 +200,8 @@ describe('Application', function() {
             app.baseApiUrl('http://api.local');
 
             entity1.url(function (entityName, viewType, identifierValue) {
-                return '/' + entityName + '_' + viewType + '/:' + identifierValue;
+                var e = encodeURIComponent;
+                return '/' + e(entityName) + '_' + e(viewType) + '/:' + e(identifierValue);
             });
 
             assert.equal(app.getRouteFor(entity1, view.getUrl(1), view.type, 1, view.identifier()), 'http://api.local/comments_EditView/:1');
@@ -216,6 +217,16 @@ describe('Application', function() {
             entity1.url('http://mock.local/entity');
 
             assert.equal(app.getRouteFor(entity1, view.getUrl(1), view.type, 1, view.identifier()), 'http://mock.local/entity');
+        });
+
+        it('should escape the entity id or name if necessary', function() {
+            var application = new Application();
+            var entity = new Entity('my things');
+            application.addEntity(entity);
+            var view = entity.listView();
+            assert.equal('my%20things', application.getRouteFor(entity, view.getUrl(), view.type));
+            var id = "thing/12";
+            assert.equal('my%20things/thing%2F12', application.getRouteFor(entity, view.getUrl(id), view.type, id, view.identifier()));
         });
     });
 

--- a/tests/lib/Queries/ReadQueriesTest.js
+++ b/tests/lib/Queries/ReadQueriesTest.js
@@ -24,9 +24,9 @@ describe('ReadQueries', () => {
     beforeEach(() => {
         application = {
             getRouteFor: (entity, generatedUrl, viewType, id) => {
-                let url = 'http://localhost/' + entity.name();
+                let url = 'http://localhost/' + encodeURIComponent(entity.name());
                 if (id) {
-                    url += '/' + id;
+                    url += '/' + encodeURIComponent(id);
                 }
 
                 return url;

--- a/tests/lib/Queries/WriteQueriesTest.js
+++ b/tests/lib/Queries/WriteQueriesTest.js
@@ -18,9 +18,9 @@ describe('WriteQueries', () => {
     beforeEach(() => {
         application = {
             getRouteFor: (entity, generatedUrl, viewType, id) => {
-                let url = 'http://localhost/' + entity.name();
+                let url = 'http://localhost/' + encodeURIComponent(entity.name());
                 if (id) {
-                    url += '/' + id;
+                    url += '/' + encodeURIComponent(id);
                 }
 
                 return url;


### PR DESCRIPTION
Fix for https://github.com/marmelab/ng-admin/issues/1041

Part of https://github.com/marmelab/ng-admin/pull/1088