### PR TITLE
custom field types based on reference field

### DIFF
--- a/src/Utils/ReferenceExtractor.js
+++ b/src/Utils/ReferenceExtractor.js
@@ -1,10 +1,13 @@
+import ReferencedListField from '../Field/ReferencedListField';
+import ReferenceField from '../Field/ReferenceField';
+
 export default {
 
     getReferencedLists(fields) {
-        return this.indexByName(fields.filter(f => f.type() === 'referenced_list'));
+        return this.indexByName(fields.filter(f => f instanceof ReferencedListField));
     },
     getReferences(fields, withRemoteComplete, optimized = null) {
-        let references = fields.filter(f => f.type() === 'reference' || f.type() === 'reference_many');
+        let references = fields.filter( f => (f instanceof ReferenceField) && !(f instanceof ReferencedListField));
         if (withRemoteComplete === true) {
             references = references.filter(r => r.remoteComplete());
         } else if (withRemoteComplete === false) {


### PR DESCRIPTION
Fixes ignoring references when extending reference field classes.
now this works fine : 

```
  var ReferencedListField=nga.getFieldConstructor('referenced_list');

  class CustomReferencedList extends ReferencedListField {
    constructor(name) {
      super(name);
      this._type = 'custom_referenced_list';
    }
  }
```