### PR TITLE
[RFR] Fix disabling view

### DIFF
--- a/src/View/MenuView.js
+++ b/src/View/MenuView.js
@@ -8,7 +8,7 @@ class MenuView extends View {
     }
 
     get enabled() {
-        return this._enabled || this.entity.views['ListView'].enabled;
+        return this._enabled === null ? this.entity._views['ListView'].enabled : this._enabled;
     }
 
     icon() {

--- a/src/View/View.js
+++ b/src/View/View.js
@@ -10,7 +10,7 @@ class View {
         this._description = '';
         this._template = null;
 
-        this._enabled = false;
+        this._enabled = null;
         this._fields = [];
         this._type = null;
         this._name = name;
@@ -21,7 +21,7 @@ class View {
     }
 
     get enabled() {
-        return this._enabled || !!this._fields.length;
+        return this._enabled === null ? !!this._fields.length : this._enabled;
     }
 
     title(title) {

--- a/tests/lib/View/MenuViewTest.js
+++ b/tests/lib/View/MenuViewTest.js
@@ -4,6 +4,40 @@ import Entity from "../../../lib/Entity/Entity";
 import MenuView from "../../../lib/View/MenuView";
 
 describe('MenuView', function() {
+
+    describe('disable()', () => {
+        it('should be disabled by default', () => {
+            const view = new MenuView();
+            view.setEntity(new Entity('post'));
+            assert.isFalse(view.enabled);
+        });
+
+        it('should be enabled if there\'s an enabled list view within the entity', () => {
+            const entity = new Entity('post');
+            entity.listView().enable();
+            var view = new MenuView();
+            view.setEntity(entity);
+            assert.isTrue(view.enabled);
+        });
+
+        it('should be disabled if there\'s a disabled list view within the entity', () => {
+            const entity = new Entity('post');
+            entity.listView().disable();
+            var view = new MenuView();
+            view.setEntity(entity);
+            assert.isFalse(view.enabled);
+        });
+
+        it('should be disabled if we disable it, even if there\'s an enabled list view within the entity', () => {
+            const entity = new Entity('post');
+            entity.listView().enable();
+            var view = new MenuView()
+            view.setEntity(entity);
+            view.disable();
+            assert.isFalse(view.enabled);
+        });
+    })
+
     describe('icon', function() {
         it('should default to list glyphicon', function() {
             var view = new MenuView(new Entity('post'));

--- a/tests/lib/View/ViewTest.js
+++ b/tests/lib/View/ViewTest.js
@@ -9,6 +9,12 @@ import View from "../../../lib/View/View";
 import ListView from "../../../lib/View/ListView";
 
 describe('View', function() {
+
+    it('should be disabled by default', () => {
+        const view = new ListView().setEntity(new Entity('foobar'));
+        assert.isFalse(view.enabled);
+    });
+
     describe('name()', function() {
         it('should return a default name based on the entity name and view type', function() {
             var view = new ListView().setEntity(new Entity('foobar'));
@@ -186,6 +192,36 @@ describe('View', function() {
                 .fields(field2);
 
             assert.deepEqual(view.fields(), [field1, field2]);
+        });
+
+        it('should enable the view when setting fields', () => {
+            var view = new View();
+
+            assert.isFalse(view.enabled);
+
+            view.fields([new Field('test')]);
+            assert.isTrue(view.enabled);
+        });
+    });
+
+    describe('disable()', () => {
+        it('should disable the view', () => {
+            const view = new View();
+            view.enable();
+            assert.isTrue(view.enabled);
+            view.disable();
+            assert.isFalse(view.enabled);
+        });
+
+        it('should disable the view even if the fields have been set', () => {
+            const view = new View();
+
+            assert.isFalse(view.enabled);
+            view.fields([new Field('test')]);
+            assert.isTrue(view.enabled);
+
+            view.disable();
+            assert.isFalse(view.enabled);
         });
     });
 


### PR DESCRIPTION
There was a problem when using, in this order:
- Set fields on editionView
- Disable the editionView
- editionView was still enabled

To solve this, we always consider views are disabled (except views without configuration: BatchDelete and DeleteView). And if any of the configuration methods are called, we set the view as enabled. We can still disable it again afterward.